### PR TITLE
Enhance DBML to Laravel Generator with Force Option, Improved Type Mapping, and Migration Handling

### DIFF
--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -9,6 +9,7 @@ class {{ modelName }} extends Model
 {
     use HasFactory;
 
+    {{ tableProperty }}
     protected $fillable = [
         {{ fillable }}
     ];


### PR DESCRIPTION
This PR significantly improves the generate:dbml command with the following enhancements:

Force Overwrite Support: Add --force option to allow overwriting existing model and migration files.

Migration Timestamp Sequencing: Introduce a counter to avoid filename collisions and preserve execution order.

Robust Error Handling: Add try-catch block for DBML parsing and validation for stub files.

Selective Generation: Skip existing files unless forced, with clear warnings.

Expanded Type Mapping: Support more DBML data types like uuid, tinyint, double, and map them properly to Laravel types.

Cleaner Model Structure: Add dynamic $table property only when necessary.

Refactored Logic: Improve code readability, type safety, and maintainability.