### PR TITLE
fix: handle unsigned foreign keys (fixes #14)

### DIFF
--- a/src/Commands/GenerateFromDbml.php
+++ b/src/Commands/GenerateFromDbml.php
@@ -388,7 +388,15 @@ class GenerateFromDbml extends Command
 
     private function buildColumnDefinition(Column $column): string
     {
-        $field = $this->resolveColumnBaseDefinition($column);
+        $name = $column->getName();
+        $type = strtolower($column->getType()->getName());
+        $reference = $column->getRefs()[0] ?? null;
+
+        $useForeignId = $reference !== null && ($type === 'bigint unsigned' || $type === '');
+
+        $field = $useForeignId
+            ? "\$table->foreignId('{$name}')"
+            : $this->resolveColumnBaseDefinition($column);
 
         if ($column->isNull()) {
             $field .= '->nullable()';
@@ -404,6 +412,29 @@ class GenerateFromDbml extends Command
 
         if ($column->isPrimaryKey() && ! $this->isAutoIncrementingPrimaryKey($column)) {
             $field .= '->primary()';
+        }
+
+        if ($reference !== null) {
+            $referencedTable = $reference->getRightTable()->getTable();
+            $referencedColumn = $reference->getReferencedColumn() ?? 'id';
+            $actions = $this->formatForeignKeyActions($reference);
+
+            if ($useForeignId) {
+                $constraint = $referencedColumn !== 'id'
+                    ? "->constrained('{$referencedTable}', '{$referencedColumn}')"
+                    : "->constrained('{$referencedTable}')";
+
+                $field .= $constraint.$actions;
+
+                return "            {$field};";
+            }
+
+            $foreignStmt = "\$table->foreign('{$name}')"
+                ."->references('{$referencedColumn}')"
+                ."->on('{$referencedTable}')"
+                .$actions;
+
+            return "            {$field};\n            {$foreignStmt};";
         }
 
         return "            {$field};";
@@ -444,18 +475,6 @@ class GenerateFromDbml extends Command
             return "\$table->enum('$name', [$enumValues])";
         }
 
-        if ($reference = $column->getRefs()[0] ?? null) {
-            $referencedTable = $reference->getRightTable()->getTable();
-            $referencedColumn = $reference->getReferencedColumn();
-            $constraint = $referencedColumn && $referencedColumn !== 'id'
-                ? "->constrained('{$referencedTable}', '{$referencedColumn}')"
-                : "->constrained('{$referencedTable}')";
-
-            $definition = "\$table->foreignId('$name'){$constraint}";
-
-            return $definition.$this->formatForeignKeyActions($reference);
-        }
-
         $stringLength = max(1, (int) ($args[0] ?? 255));
         $charLength = max(1, (int) ($args[0] ?? 255));
         $precision = max(1, (int) ($args[0] ?? 8));
@@ -475,9 +494,15 @@ class GenerateFromDbml extends Command
             'double' => "\$table->double('$name')",
             'float' => "\$table->float('$name')",
             'numeric', 'decimal' => "\$table->decimal('$name', {$precision}, {$scale})",
+            'bigint unsigned' => "\$table->unsignedBigInteger('$name')",
+            'int unsigned', 'integer unsigned' => "\$table->unsignedInteger('$name')",
+            'smallint unsigned' => "\$table->unsignedSmallInteger('$name')",
+            'tinyint unsigned' => "\$table->unsignedTinyInteger('$name')",
+            'mediumint unsigned' => "\$table->unsignedMediumInteger('$name')",
             'bigint', 'bigserial' => "\$table->bigInteger('$name')",
             'smallint', 'smallserial' => "\$table->smallInteger('$name')",
             'tinyint' => "\$table->tinyInteger('$name')",
+            'mediumint' => "\$table->mediumInteger('$name')",
             'serial', 'int', 'integer' => "\$table->integer('$name')",
             default => "\$table->string('$name')",
         };

--- a/tests/Feature/GenerateFromDbmlCommandTest.php
+++ b/tests/Feature/GenerateFromDbmlCommandTest.php
@@ -43,8 +43,55 @@ it('generates models and migrations from DBML', function () {
 
         $migrationContents = file_get_contents($usersMigration);
         expect($migrationContents)
-            ->toContain("foreignId('country_code')->constrained('countries', 'code')")
+            ->toContain("\$table->string('country_code', 255)")
+            ->toContain("\$table->foreign('country_code')->references('code')->on('countries')")
             ->toContain("enum('role'");
+    } finally {
+        Carbon::setTestNow();
+        $application->useAppPath($originalAppPath);
+        $application->useDatabasePath($originalDatabasePath);
+        $filesystem->deleteDirectory($baseTempPath);
+    }
+});
+
+it('respects column type when generating foreign key constraints', function () {
+    $filesystem = new Filesystem();
+    $baseTempPath = base_path('tests/.tmp/'.uniqid('dbml_typed_fk_', true));
+    $appPath = $baseTempPath.'/app';
+    $databasePath = $baseTempPath.'/database';
+
+    $filesystem->makeDirectory($appPath.'/Models', 0755, true, true);
+    $filesystem->makeDirectory($databasePath.'/migrations', 0755, true, true);
+
+    $application = app();
+    $originalAppPath = $application->path();
+    $originalDatabasePath = $application->databasePath();
+
+    $application->useAppPath($appPath);
+    $application->useDatabasePath($databasePath);
+
+    Carbon::setTestNow(Carbon::create(2024, 1, 2, 10));
+
+    try {
+        $fixture = __DIR__.'/../Fixtures/unsigned-fk.dbml';
+
+        artisan('generate:dbml', ['file' => $fixture, '--force' => true])
+            ->assertExitCode(Command::SUCCESS);
+
+        $migrationFiles = glob($databasePath.'/migrations/*.php');
+        $ordersMigration = collect($migrationFiles)
+            ->first(fn (string $file) => str_contains($file, 'create_orders_table'));
+
+        expect($ordersMigration)->not->toBeNull();
+
+        $contents = file_get_contents($ordersMigration);
+        expect($contents)
+            ->toContain("\$table->unsignedInteger('user_id')")
+            ->toContain("\$table->foreign('user_id')->references('id')->on('users')")
+            ->toContain("\$table->foreignId('product_id')->constrained('products')")
+            ->toContain("\$table->string('coupon_code', 255)")
+            ->toContain("\$table->foreign('coupon_code')->references('code')->on('coupons')")
+            ->not->toContain("foreignId('user_id')");
     } finally {
         Carbon::setTestNow();
         $application->useAppPath($originalAppPath);

--- a/tests/Fixtures/unsigned-fk.dbml
+++ b/tests/Fixtures/unsigned-fk.dbml
@@ -1,0 +1,18 @@
+Table orders {
+  id bigint [pk, increment]
+  user_id "int unsigned" [not null, ref: > users.id]
+  product_id "bigint unsigned" [not null, ref: > products.id]
+  coupon_code varchar [ref: > coupons.code]
+}
+
+Table users {
+  id "int unsigned" [pk]
+}
+
+Table products {
+  id "bigint unsigned" [pk, increment]
+}
+
+Table coupons {
+  code varchar [pk]
+}


### PR DESCRIPTION
## Description
- Adjust migration generation to respect column types for foreign keys and produce appropriate foreign key statements.
- Move foreignId logic into buildColumnDefinition: use foreignId()->constrained(...) for big integer unsigned FKs and generate $table->foreign(...)->references(...)->on(...) for other references, preserving onDelete/onUpdate actions.
- Add mappings for various integer types.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally
- [x] New tests added (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
